### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -42,3 +42,14 @@ body {
 .alert-alert {
   @extend .alert-danger;
 }
+
+
+// テキスト・動画一覧系画面共通
+.card-list-wrapper{
+  margin-top: 60px;
+}
+
+// 動画教材一覧画面
+.movie-card-body{
+  height: 200px;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,0 +1,7 @@
+class MoviesController < ApplicationController
+  def index
+    # 取得対象ジャンル
+    genre_list = %W(Basic Git HTML&CSS Ruby Ruby on Rails)
+    @movies = Movie.where(genre: genre_list)
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,7 @@
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
           <%= link_to "Ruby/Rails教材", root_path, class: "dropdown-item" %>
-          <%= link_to "動画教材", "#", class: "dropdown-item" %>
+          <%= link_to "動画教材", movies_path , class: "dropdown-item" %>
           <%= link_to "AWS講座", "#", class: "dropdown-item" %>
           <%= link_to "プログラミング勉強会", "#", class: "dropdown-item" %>
           <%= link_to "質問集", "#", class: "dropdown-item" %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,15 @@
+<div class="conatiner card-list-wrapper">
+  <div class="row">
+    <% @movies.each.with_index(1) do |movie, index| %>
+      <div class="col-12 col-md-6 col-lg-4">
+        <div class="card mt-3">
+          <iframe src= <%= movie.url %> frameborder="0" height="250"></iframe>
+          <div class="card-body movie-card-body">
+            <p><button href="#" class="btn btn-secondary btn-block">視聴済みにする</button></p>
+            <p class="card-title">Lv<%= index %>：<%= movie.title %></p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root to: 'texts#index'
+  resources :movies, only:  %w(index)
 end


### PR DESCRIPTION
## #28

close #28

## 実装内容

- Rails動画教材画面の実装
  - `movies`コントローラの追加と、`index`アクションの実装
  - `index`アクションのルーティングの追加
  - 動画教材一覧画面の追加
    - `scss`に一覧画面用のスタイルを追加
  - 以下のジャンルのレコードのみ出力
    - ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]

- ヘッダーに動画一覧画面へのリンクを追加

マークダウン記法のリンクを用いて記載すること
- 動画教材一覧画面の実装
  - [YouTubeの動画を埋め込む方法](https://qiita.com/shutokawabata0723/items/ca6d5b52ba8bfcbf5c42)
- ルーティングの追加
  - [Railsのルーティングをカスタマイズしたときのメモ](https://qiita.com/dkurata38/items/273f380853f24bc69da8)

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考（必要があれば）
`taisei` さん、同様に一覧ページを実装しているため、ヘッダーのリンク等を編集した際にコンフリクトが起きる可能性があります。また共通で使用できるCSSを`application.scss`一部追加しておりますのでご確認お願い致します。
