### PR TITLE
Railsテキスト教材詳細ページの実装#27

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,12 @@ gem "devise-i18n"
 # アクティブアドミン
 gem "activeadmin"
 
+# markdown
+gem 'redcarpet'
+
+# シンタックスハイライト
+gem 'coderay'
+
 # デバックツール
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -250,6 +251,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -260,6 +262,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,10 +49,6 @@ body {
   margin-top: 60px;
 }
 
-.noline {
-  text-decoration: none;
-}
-
 // 動画教材一覧画面
 .movie-card-body{
   height: 200px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,6 +49,10 @@ body {
   margin-top: 60px;
 }
 
+.noline {
+  text-decoration: none;
+}
+
 // 動画教材一覧画面
 .movie-card-body{
   height: 200px;

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -3,4 +3,8 @@ class TextsController < ApplicationController
     genre_list = ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]
     @texts = Text.where(genre: genre_list)
   end
+
+  def show
+    @text = Text.find(params[:id])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,51 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(":")[0] if language.present?
+
+      case language.to_s
+      when "rb"
+        lang = :ruby
+      when "yml"
+        lang = :yaml
+      when "css"
+        lang = :css
+      when "html"
+        lang = :html
+      when ""
+        lang = :md
+      else
+        lang = language
+      end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: "nofollow", target: "_blank" },
+    )
+    options = {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true,
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text).html_safe
+  end
+
   def max_width
     "mw-xl"
   end

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -6,13 +6,15 @@
   </div>
 
   <div class="row">
-  <% @texts.each do |text| %>
+    <% @texts.each do |text| %>
     <div class="col-12 col-md-6 col-lg-4">
       <div class="card card-style">
-        <a target="_blank" href="/texts/<%= text.id %>">
+        <a class="noline" target="_blank" href="/texts/<%= text.id %>">
           <svg class="bd-placeholder-img card-img-top w-100" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
           <div class="card-body">
-            <a href="#" class="btn btn-secondary w-100">視聴済みにする</a>
+            <object>
+              <a href="#" class="btn btn-secondary w-100">視聴済みにする</a>
+            </object>
             <p class="card-text"><%= text.title %></p>
             <p class="card-title">【<%= text.genre %>】</p>
           </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -9,7 +9,7 @@
     <% @texts.each do |text| %>
     <div class="col-12 col-md-6 col-lg-4">
       <div class="card card-style">
-        <a class="noline" target="_blank" href="/texts/<%= text.id %>">
+        <a class="text-decoration-none" target="_blank" href="/texts/<%= text.id %>">
           <svg class="bd-placeholder-img card-img-top w-100" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
           <div class="card-body">
             <object>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -9,12 +9,14 @@
   <% @texts.each do |text| %>
     <div class="col-12 col-md-6 col-lg-4">
       <div class="card card-style">
-        <svg class="bd-placeholder-img card-img-top w-100" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-        <div class="card-body">
-          <a href="#" class="btn btn-secondary w-100">視聴済みにする</a>
-          <p class="card-text"><%= text.title %></p>
-          <p class="card-title">【<%= text.genre %>】</p>
-        </div>
+        <a target="_blank" href="/texts/<%= text.id %>">
+          <svg class="bd-placeholder-img card-img-top w-100" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+          <div class="card-body">
+            <a href="#" class="btn btn-secondary w-100">視聴済みにする</a>
+            <p class="card-text"><%= text.title %></p>
+            <p class="card-title">【<%= text.genre %>】</p>
+          </div>
+        </a>
       </div>
     </div>
     <% end %>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -8,7 +8,7 @@
       <%= markdown(@text.content) %>
     </div>
     <div class="raed-text">
-      <a href="#" class="btn-secondary btn-block">読破済みにする</a>
+      <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
     </div>
   </section>
 </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,14 @@
+<div class="base-container mw-md">
+  <section>
+    <h2 class="text-title"><%= @text.title %></h2>
+    <div class="movie_info_box">
+      <p>動画教材を試聴された上で、テキスト教材を元に手を動かすようにして下さい。</p>
+    </div>
+    <div class="markdown">
+      <%= markdown(@text.content) %>
+    </div>
+    <div class="raed-text">
+      <a href="#" class="btn-secondary btn-block">読破済みにする</a>
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
close #27 

## 実装内容
- Markdownを導入
  - gem 'redcarpet' gem 'coderay'を追加
- テキスト教材詳細ページの作成
- 一覧ページに詳細ページへのリンクを実装

## 参考資料
- [RailsアプリへのMarkdownの導入](https://arcane-gorge-21903.herokuapp.com/texts/224)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
