### PR TITLE
#47テキスト教材進捗管理モデルの作成

### DIFF
--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,7 @@
 class Text < ApplicationRecord
+  has_many :text_progresses, dependent: :destroy
+  has_many :users, through: :text_progresses
+
   validates :genre, presence: true
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/text_progress.rb
+++ b/app/models/text_progress.rb
@@ -1,0 +1,4 @@
+class TextProgress < ApplicationRecord
+  belongs_to :user_id
+  belongs_to :text_id
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  has_many :text_progresses, dependent: :destroy
+  has_many :texts, through: :text_progresses
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20210109084211_create_text_progresses.rb
+++ b/db/migrate/20210109084211_create_text_progresses.rb
@@ -2,8 +2,8 @@ class CreateTextProgresses < ActiveRecord::Migration[6.0]
   def change
     create_table :text_progresses do |t|
       t.boolean :complete_flg, null: false, default: false
-      t.references :user_id, null: false, foreign_key: true
-      t.references :text_id, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20210109084211_create_text_progresses.rb
+++ b/db/migrate/20210109084211_create_text_progresses.rb
@@ -1,0 +1,12 @@
+class CreateTextProgresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :text_progresses do |t|
+      t.boolean :complete_flg, null: false, default: false
+      t.references :user_id, null: false, foreign_key: true
+      t.references :text_id, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :text_progresses, [:user_id, :text_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_31_042215) do
+ActiveRecord::Schema.define(version: 2021_01_09_084211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,17 @@ ActiveRecord::Schema.define(version: 2020_12_31_042215) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "text_progresses", force: :cascade do |t|
+    t.boolean "complete_flg", default: false, null: false
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_text_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_text_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_text_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.string "genre"
     t.string "title"
@@ -69,4 +80,6 @@ ActiveRecord::Schema.define(version: 2020_12_31_042215) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "text_progresses", "texts"
+  add_foreign_key "text_progresses", "users"
 end


### PR DESCRIPTION
close #47 

## 実装内容
- テキスト教材進捗管理モデルの作成
  - 進捗ステータスcomplete_flgはデフォルト値にfalseを設定
  - user_idとtext_idに一意制約を設定
- モデルの関連付け
  - userモデル、textモデルとの関連付け

## 参考資料
- [モデルの関連付け　その２（多対多）](https://arcane-gorge-21903.herokuapp.com/texts/297)
- [Rails 複数のカラムに 一意制約 (ユニーク)を設ける](http://yamakichi.hatenablog.com/entry/2016/08/25/003738)
- [Rails『アソシエーション』チュートリアル](https://qiita.com/kazukimatsumoto/items/14bdff681ec5ddac26d1#%E3%81%8A%E6%B0%97%E3%81%AB%E5%85%A5%E3%82%8A%E6%A9%9F%E8%83%BD%E3%82%92er%E5%9B%B3%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6%E8%A8%AD%E8%A8%88%E3%81%97%E3%82%88%E3%81%86Rails)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
テキスト進捗管理モデル作成時にエラーが発生していることに気づかずコミットしてしまいました。
そのため【テキスト進捗管理モデルの作成】のコミットを２つしてしまいました。