### PR TITLE
動画教材一覧画面 ボタンの切り替え処理実装

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,3 +3,21 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("bootstrap/dist/js/bootstrap")
+
+// ボタン切り替え用処理
+$(function() {
+  const btn_message = ["視聴済みにする","視聴済みを解除"]
+  const btn_color = ["btn-primary", "btn-secondary"]
+  $( '.btn').on('click', function(){
+    if($(this).hasClass('btn-secondary')){
+      change_button($(this), btn_message[1], btn_color[1], btn_color[0]);
+    } else {
+      change_button($(this), btn_message[0], btn_color[0], btn_color[1]);
+    }
+  });
+  function change_button (btn, message, remove_color, add_color){
+    btn.text(message);
+    btn.removeClass(remove_color);
+    btn.addClass(add_color);
+  };
+});

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -5,7 +5,7 @@
         <div class="card mt-3">
           <iframe src= <%= movie.url %> frameborder="0" height="250"></iframe>
           <div class="card-body movie-card-body">
-            <p><button href="#" class="btn btn-secondary btn-block">視聴済みにする</button></p>
+            <p><%= button_tag "視聴済みにする", type: 'button', class: "btn btn-secondary btn-block" %></p>
             <p class="card-title">Lv<%= index %>：<%= movie.title %></p>          
           </div>
         </div>
@@ -15,4 +15,3 @@
 </div>
 
 <%= paginate @movies%>
-


### PR DESCRIPTION
close #50

## 実装内容

- 動画教材一覧ページ
  - `button`タグを`button_tag`のヘルパーメソッドに変更
  - ボタンを押下した際に、ボタンの表示文字と背景色が状態に合わせて変更する処理を実装

## 参考資料

- ログイン機能
  - [やんばるCODEアプリ](https://arcane-gorge-21903.herokuapp.com/texts/219)

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット

## 備考（必要があれば）
次回以降のタスクで`ajax`等を実装し、ボタンの切り替え処理も合わせて変更を行う