### PR TITLE
動画教材進捗モデル テーブル定義の変更

### DIFF
--- a/db/migrate/20210115140224_remove_complete_flg_from_movie_progresses.rb
+++ b/db/migrate/20210115140224_remove_complete_flg_from_movie_progresses.rb
@@ -1,0 +1,5 @@
+class RemoveCompleteFlgFromMovieProgresses < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :movie_progresses, :complete_flg, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_09_084211) do
+ActiveRecord::Schema.define(version: 2021_01_15_140224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,6 @@ ActiveRecord::Schema.define(version: 2021_01_09_084211) do
   create_table "movie_progresses", force: :cascade do |t|
     t.bigint "user_id", null: false, comment: "ユーザーID"
     t.bigint "movie_id", null: false, comment: "動画ID"
-    t.boolean "complete_flg", default: false, null: false, comment: "進捗ステータス"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id", "movie_id"], name: "index_movie_progresses_on_user_id_and_movie_id", unique: true


### PR DESCRIPTION
close #61

## 実装内容

- movie_progressesモデルから、ステータス情報を持つ`complete_flg`を削除する
  - カラム削除用のマイグレーションファイルを作成して `rails db:migrate`を実行する

###### 削除理由
※ステータスを実装で必要としないため

## 参考資料

- ログイン機能
  - [Quita Ruby on Rails カラムの追加と削除](https://qiita.com/azusanakano/items/a2847e4e582b9a627e3a)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
