### PR TITLE
テキスト教材進捗モデルの定義を変更

### DIFF
--- a/db/migrate/20210117073206_remove_complete_flg_from_text_progresses.rb
+++ b/db/migrate/20210117073206_remove_complete_flg_from_text_progresses.rb
@@ -1,0 +1,5 @@
+class RemoveCompleteFlgFromTextProgresses < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :text_progresses, :complete_flg, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_15_140224) do
+ActiveRecord::Schema.define(version: 2021_01_17_073206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,6 @@ ActiveRecord::Schema.define(version: 2021_01_15_140224) do
   end
 
   create_table "text_progresses", force: :cascade do |t|
-    t.boolean "complete_flg", default: false, null: false
     t.bigint "user_id", null: false
     t.bigint "text_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
close #65

## 実装内容
- text_progressesモデルから、ステータス情報を持つcomplete_flgを削除
  - カラム削除用のマイグレーションファイルを作成

## 参考資料

[カラムを追加・削除・編集する方法 ❏Rails❏](https://qiita.com/ITmanbow/items/2bf4dfa4d9ca705b97df)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認